### PR TITLE
Change the format to read data from sources

### DIFF
--- a/lib/ibge.rb
+++ b/lib/ibge.rb
@@ -6,13 +6,14 @@ module Ibge
   DATA_PATH = File.expand_path(File.join(__dir__, '..', 'data'))
 
   module Reader
-    autoload :Base,         'ibge/reader/base'
-    autoload :State,        'ibge/reader/state'
-    autoload :MesoRegion,   'ibge/reader/meso_region'
-    autoload :MicroRegion,  'ibge/reader/micro_region'
-    autoload :Municipality, 'ibge/reader/municipality'
-    autoload :District,     'ibge/reader/district'
-    autoload :SubDistrict,  'ibge/reader/sub_district'
-    autoload :Neighborhood, 'ibge/reader/neighborhood'
+    autoload :Helpers, "ibge/reader/helpers"
+    autoload :Base, "ibge/reader/base"
+    autoload :State, "ibge/reader/state"
+    autoload :MesoRegion, "ibge/reader/meso_region"
+    autoload :MicroRegion, "ibge/reader/micro_region"
+    autoload :Municipality, "ibge/reader/municipality"
+    autoload :District, "ibge/reader/district"
+    autoload :SubDistrict, "ibge/reader/sub_district"
+    autoload :Neighborhood, "ibge/reader/neighborhood"
   end
 end

--- a/lib/ibge/reader/helpers.rb
+++ b/lib/ibge/reader/helpers.rb
@@ -1,0 +1,78 @@
+module Ibge
+  module Reader
+    module Helpers
+      SOURCES = {
+        dtb: "DTB_2014_subdistrito.xls",
+        sidra: "sidra.xls"
+      }
+
+      attr_reader :defined_columns, :selected_source
+
+      def columns(columns)
+        if columns.empty?
+          raise ArgumentError,
+                "Columns must be provided as hash which contains " /
+                  "the index and field name"
+        end
+
+        @defined_columns ||= {}
+        @selected_source ||= :dtb
+
+        distinct_sources = []
+
+        columns.each do |_, v|
+          if v.is_a?(Hash)
+            hash_column_definition = v.values.first
+
+            unless hash_column_definition.key?(:from_source)
+              raise ArgumentError, "#{v.key} must have the key from_source"
+            end
+
+            valid_informed_source(hash_column_definition[:from_source])
+
+            distinct_sources << hash_column_definition[:from_source]
+          end
+        end
+
+        distinct_sources = distinct_sources.compact.uniq.sort
+
+        distinct_sources.each do |source|
+          extracted_columns = columns.select do |_, v|
+            v.is_a?(Hash) && v.values.first[:from_source] == source
+          end
+
+          @defined_columns[source] = extracted_columns.inject({}) do |h, (k, v)|
+            h.merge!(k.to_s.to_sym => v.is_a?(Hash) ? v.keys.first : v)
+
+            h
+          end
+        end
+
+        if @selected_source
+          @defined_columns[@selected_source] = columns.select do |_, v|
+            v.is_a?(Symbol)
+          end
+        end
+      end
+
+      def source(selected_source = :dtb)
+        valid_informed_source(selected_source)
+
+        @selected_source = selected_source
+      end
+
+      def sources
+        SOURCES
+      end
+
+      def valid_informed_source(informed_source)
+        source_keys = sources.keys
+
+        unless source_keys.include?(informed_source)
+          raise ArgumentError,
+                "Source must be one of those '#{source_keys.join(', ')}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/ibge/reader/state.rb
+++ b/lib/ibge/reader/state.rb
@@ -1,11 +1,9 @@
 module Ibge
   module Reader
     class State < Base
-      source :sidra
-
       columns "0": :code,
               "1": :state_name,
-              "2": :state_federative_unit
+              "2": { state_federative_unit: { from_source: :sidra } }
     end
   end
 end

--- a/spec/ibge/reader/base_spec.rb
+++ b/spec/ibge/reader/base_spec.rb
@@ -1,47 +1,97 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Ibge::Reader::Base do
-  class Reader < Ibge::Reader::Base
-    source :sidra
+  context "source on top of the reader" do
+    class ReaderWithSource < Ibge::Reader::Base
+      source :sidra
 
-    columns "0": :code
-  end
-
-  subject { Reader }
-
-  describe '.columns' do
-    it { should respond_to :columns }
-
-    it 'maps the column index to a recognized column name' do
-      expect(subject.defined_columns).to eq "0": :code
+      columns "0": :code
     end
-  end
 
-  describe '.read' do
-    context 'without pass a :filename as option' do
-      it 'reads the file inside data folder' do
-        expect(subject.read).to include code: "11"
+    subject { ReaderWithSource }
+
+    describe ".columns" do
+      it { should respond_to :columns }
+
+      it "maps the column index to a recognized column name" do
+        expect(subject.defined_columns).to eq sidra: { "0": :code }
       end
     end
 
-    context 'passing a :filename' do
-      it 'reads the file provided' do
-        filename = "spec/fixtures/DTB_example_subdistrito.xls"
+    describe ".read" do
+      context "without pass a :filename as option" do
+        it "reads the file inside data folder" do
+          expect(subject.read).to include code: "11"
+        end
+      end
 
-        expect(subject.read(filename: filename)).to include code: "11"
+      context "passing a :filename" do
+        it "reads the file provided" do
+          filename = "spec/fixtures/DTB_example_subdistrito.xls"
+
+          content = subject.read(filename: { dtb: filename })
+
+          expect(content).to include code: "11"
+        end
+      end
+    end
+
+    describe ".selected_source" do
+      it "show the default file source to read" do
+        expect(subject.selected_source).to eq :sidra
+      end
+    end
+
+    describe "#filename" do
+      it "sets the default to file inside data folder" do
+        expect(subject.new.filename).to include "data/sidra.xls"
       end
     end
   end
 
-  describe '.selected_source' do
-    it 'show the default file source to read' do
-      expect(subject.selected_source).to eq :sidra
+  context "without source defined" do
+    class ReaderWithoutSource < Ibge::Reader::Base
+      columns "0": :code
     end
-  end
 
-  describe '#filename' do
-    it 'sets the default to file inside data folder' do
-      expect(subject.new.filename).to include 'data/sidra.xls'
+    subject { ReaderWithoutSource }
+
+    describe ".columns" do
+      it { should respond_to :columns }
+
+      it "maps the column index to a recognized column name" do
+        expect(subject.defined_columns).to eq dtb: { "0": :code }
+      end
+    end
+
+    describe ".read" do
+      context "without pass a :filename as option" do
+        it "reads the file inside data folder" do
+          expect(subject.read).to include code: "11"
+        end
+      end
+
+      context "passing a :filename" do
+        it "reads the file provided" do
+          filename = "spec/fixtures/DTB_example_subdistrito.xls"
+
+          content = subject.read(filename: { dtb: filename })
+
+          expect(content).to include code: "11"
+        end
+      end
+    end
+
+    describe ".selected_source" do
+      it "show the default file source to read" do
+        expect(subject.selected_source).to eq :dtb
+      end
+    end
+
+    describe "#filename" do
+      it "sets the default to file inside data folder" do
+        expect(subject.new.filename).to include "data/DTB_2014_subdistrito.xls"
+      end
     end
   end
 end

--- a/spec/ibge/reader/district_spec.rb
+++ b/spec/ibge/reader/district_spec.rb
@@ -3,13 +3,21 @@ require 'spec_helper'
 describe Ibge::Reader::District do
   subject { described_class }
 
+  let(:columns) do
+    {
+      dtb: {
+        "0": :state_code,
+        "2": :meso_region_code,
+        "4": :micro_region_code,
+        "6": :municipality_code,
+        "9": :code,
+        "10": :full_code,
+        "11": :name
+      }
+    }
+  end
+
   it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0": :state_code,
-                                               "2": :meso_region_code,
-                                               "4": :micro_region_code,
-                                               "6": :municipality_code,
-                                               "9": :code,
-                                               "10": :full_code,
-                                               "11": :name
+    expect(subject.defined_columns).to eq columns
   end
 end

--- a/spec/ibge/reader/meso_region_spec.rb
+++ b/spec/ibge/reader/meso_region_spec.rb
@@ -3,9 +3,17 @@ require 'spec_helper'
 describe Ibge::Reader::MesoRegion do
   subject { described_class }
 
+  let(:columns) do
+    {
+      dtb: {
+        "0": :state_code,
+        "2": :code,
+        "3": :name
+      }
+    }
+  end
+
   it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0": :state_code,
-                                               "2": :code,
-                                               "3": :name
+    expect(subject.defined_columns).to eq columns
   end
 end

--- a/spec/ibge/reader/micro_region_spec.rb
+++ b/spec/ibge/reader/micro_region_spec.rb
@@ -3,10 +3,18 @@ require 'spec_helper'
 describe Ibge::Reader::MicroRegion do
   subject { described_class }
 
+  let(:columns) do
+    {
+      dtb: {
+        "0": :state_code,
+        "2": :meso_region_code,
+        "4": :code,
+        "5": :name
+      }
+    }
+  end
+
   it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0": :state_code,
-                                               "2": :meso_region_code,
-                                               "4": :code,
-                                               "5": :name
+    expect(subject.defined_columns).to eq columns
   end
 end

--- a/spec/ibge/reader/municipality_spec.rb
+++ b/spec/ibge/reader/municipality_spec.rb
@@ -3,12 +3,20 @@ require 'spec_helper'
 describe Ibge::Reader::Municipality do
   subject { described_class }
 
+  let(:columns) do
+    {
+      dtb: {
+        "0": :state_code,
+        "2": :meso_region_code,
+        "4": :micro_region_code,
+        "6": :code,
+        "7": :full_code,
+        "8": :name
+      }
+    }
+  end
+
   it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0": :state_code,
-                                               "2": :meso_region_code,
-                                               "4": :micro_region_code,
-                                               "6": :code,
-                                               "7": :full_code,
-                                               "8": :name
+    expect(subject.defined_columns).to eq columns
   end
 end

--- a/spec/ibge/reader/neighborhood_spec.rb
+++ b/spec/ibge/reader/neighborhood_spec.rb
@@ -3,7 +3,17 @@ require 'spec_helper'
 describe Ibge::Reader::Neighborhood do
   subject { described_class }
 
+  let(:columns) do
+    {
+      sidra: {
+        "0": :state_code,
+        "3": :municipality_full_code,
+        "5": :name
+      }
+    }
+  end
+
   it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0": :state_code, "3": :municipality_full_code, "5": :name
+    expect(subject.defined_columns).to eq columns
   end
 end

--- a/spec/ibge/reader/state_spec.rb
+++ b/spec/ibge/reader/state_spec.rb
@@ -1,9 +1,28 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Ibge::Reader::State do
   subject { described_class }
 
-  it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0": :code, "1": :state_name
+  let(:columns) do
+    {
+      dtb: {
+        "0": :code,
+        "1": :state_name
+      },
+
+      sidra: {
+        "2": :state_federative_unit
+      }
+    }
+  end
+
+  it "should have defined columns" do
+    expect(subject.defined_columns).to eq columns
+  end
+
+  it "should read from multiple sources" do
+    expect(subject.read).to include code: "11",
+                                    state_name: "Rondônia",
+                                    state_federative_unit: "RO"
   end
 end

--- a/spec/ibge/reader/sub_district_spec.rb
+++ b/spec/ibge/reader/sub_district_spec.rb
@@ -3,14 +3,22 @@ require 'spec_helper'
 describe Ibge::Reader::SubDistrict do
   subject { described_class }
 
+  let(:columns) do
+    {
+      dtb: {
+        "0": :state_code,
+        "2": :meso_region_code,
+        "4": :micro_region_code,
+        "6": :municipality_code,
+        "9": :district_code,
+        "12": :code,
+        "13": :full_code,
+        "14": :name
+      }
+    }
+  end
+
   it 'should have defined columns' do
-    expect(subject.defined_columns).to include "0":  :state_code,
-                                               "2":  :meso_region_code,
-                                               "4":  :micro_region_code,
-                                               "6":  :municipality_code,
-                                               "9":  :district_code,
-                                               "12": :code,
-                                               "13": :full_code,
-                                               "14": :name
+    expect(subject.defined_columns).to include columns
   end
 end


### PR DESCRIPTION
Before the source is needed on top of the reader to define from which
source will read, but in some cases needs one specific column from one
source and the principal source reads another columns